### PR TITLE
Also show non-fronting members, but greyed-out

### DIFF
--- a/credits.html
+++ b/credits.html
@@ -21,6 +21,7 @@
         <li>Purrrpley
             <ul>
                 <li>Helping out with CSS stuff</li>
+                <li>Added the displaying of non-fronting members in partially transparent cards, sorted after fronting members</li>
             </ul>
         </li>
     </ul>

--- a/fronters.css
+++ b/fronters.css
@@ -3,7 +3,7 @@ img {
     max-width: 200px;
     max-height: 200px;
     /* border: 2px solid #F0F0F0; */
-    border-radius: 5%;
+    border-radius: 0 5% 5% 0;
     margin-right: 10px;
 }
 

--- a/fronters.css
+++ b/fronters.css
@@ -29,7 +29,10 @@ a {
     /* Resize the card so it always fits the avatar */
     overflow: auto;
     /* Add a gap around the cards */
-    margin: 1em;
+    margin: 0 1em 1em 0;
+    /* Cards should go left-to-right, top-to-bottom, instead of just
+    top-to-bottom */
+    float: left;
 }
 
 .card img {

--- a/fronters.css
+++ b/fronters.css
@@ -9,7 +9,7 @@ img {
 
 /* Main page styling */
 body {
-    background-color: #37393f;
+    background-color: #36393f;
     color: white;
     font-family:'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
     
@@ -29,7 +29,7 @@ a {
 /* Embed-style fronter items */
 .fronter {
     background-color: #2f3136;
-    border-radius: 5px;
+    border-radius: 4px;
     border-left: 4px solid #202225;
     width: 300px;
     overflow: auto;

--- a/fronters.css
+++ b/fronters.css
@@ -1,12 +1,3 @@
-/* Max avatar size */
-img {
-    max-width: 200px;
-    max-height: 200px;
-    /* border: 2px solid #F0F0F0; */
-    border-radius: 0 5% 5% 0;
-    margin-right: 10px;
-}
-
 /* Main page styling */
 body {
     background-color: #36393f;
@@ -26,11 +17,39 @@ a {
     font-size: 40px;
 }
 
-/* Embed-style fronter items */
-.fronter {
+/* Discord embed-style cards */
+.card {
     background-color: #2f3136;
     border-radius: 4px;
-    border-left: 4px solid #202225;
-    width: 300px;
+    width: 25em;
+    height: 200px;
+    /* Left border (colour is specified in JS) */
+    border-left-style: solid;
+    border-left-width: 4px;
+    /* Resize the card so it always fits the avatar */
     overflow: auto;
+    /* Add a gap around the cards */
+    margin: 1em;
+}
+
+.card img {
+    /* Max avatar size */
+    max-width: 200px;
+    max-height: 200px;
+    /* Vertically centered */
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    /* Float to the left of the text */
+    float: left;
+    /* Gap between text and avatar */
+    margin-right: 1em;
+    /* Curve the right corners, but not the left ones that are against the
+    left border of the card */
+    border-radius: 0 5% 5% 0;
+}
+
+/* Make the cards for non-fronting members partially transparent */
+.card.non-fronting {
+    opacity: 25%;
 }

--- a/fronters.js
+++ b/fronters.js
@@ -2,6 +2,7 @@
     Credits for code:
     Ringlings
     Alli
+    Purrrpley
 */
 
 // Collect system ID from query string
@@ -11,31 +12,24 @@ const system = new URLSearchParams(queryString).get("sys");
 // Main document container
 const container = document.querySelector('.container');
 
-// Return fronters from pk api via the querystring
-async function getFronters() {
-    // Fetch from the pk api
-    let response = await fetch("https://api.pluralkit.me/v2/systems/" + system + "/fronters");
-
-    // Handle erorr if there is any
+// Helper function for interacting with the PluralKit API
+async function pkAPI(path) {
+    // Fetch from the PluralKit API
+    let response = await fetch('https://api.pluralkit.me/v2/' + path)
+    // Handle error if there is one
     if (response.status != 200) {
         showInput(response.status)
         return null
     }
-
-    // Return the fronters if there is no error
     return await response.json()
 }
 
-// Fetches system information (Alli)
-async function getSystem() {
-    let response = await fetch("https://api.pluralkit.me/v2/systems/" + system);
+async function getFronters(system) {
+    return await pkAPI(`systems/${system}/fronters`)
+}
 
-    if (response.status != 200) {
-        showInput(response.status)
-        return null
-    }
-
-    return await response.json()
+async function getSystem(system) {
+    return await pkAPI(`systems/${system}`)
 }
 
 function backButton() {
@@ -54,8 +48,8 @@ function backButton() {
 }
 
 // Renders the list of current fronters
-async function renderFronters() {
-    const fronters = await getFronters();
+async function renderFronters(system) {
+    const fronters = await getFronters(system);
 
     // Handle system being switched out
     if (fronters.members.length == 0) {
@@ -65,7 +59,7 @@ async function renderFronters() {
     }
 
     // System name logic (Alli)
-    const sysObject = await getSystem();
+    const sysObject = await getSystem(system);
 
     // System name container
     const nameContainer = document.getElementById("name-container");
@@ -177,7 +171,7 @@ function showInput(reason) {
 if (system != null & system != "") {
     // Display fronters for requested system
     container.innerHTML = `<code>Loading fronters...</code>`
-    renderFronters();
+    renderFronters(system);
 }
 else {
     // Display system input

--- a/fronters.js
+++ b/fronters.js
@@ -25,11 +25,33 @@ async function pkAPI(path) {
 }
 
 async function getFronters(system) {
-    return await pkAPI(`systems/${system}/fronters`)
+    let fronters = (await pkAPI(`systems/${system}/fronters`)).members
+    // Return only the UUIDs. The other data we get from the `getMembers()`
+    // call, so we only need to store it there and not here too. If the system
+    // is switched out, it will return an empty array.
+    return fronters.map(i => {
+        return i.uuid
+    })
 }
 
-async function getSystem(system) {
+async function getMembers(system) {
+    return await pkAPI(`systems/${system}/members`)
+}
+
+async function getSystemInfo(system) {
     return await pkAPI(`systems/${system}`)
+}
+
+// Separate members into groups depending on whether they're fronting or not
+function separateMembers(fronting, members) {
+    return {
+        'fronting': members.filter(member => {
+            return fronting.indexOf(member.uuid) != -1
+        }),
+        'nonFronting': members.filter(member => {
+            return fronting.indexOf(member.uuid) == -1
+        })
+    }
 }
 
 function backButton() {
@@ -47,36 +69,52 @@ function backButton() {
 
 }
 
-// Renders the list of current fronters
-async function renderFronters(system) {
-    const fronters = await getFronters(system);
-
-    // Handle system being switched out
-    if (fronters.members.length == 0) {
-        container.innerHTML = `<p>This system is currently switched out.</p>`
-        backButton()
-        return
+async function renderCard(member, isFronting) {
+    /* TODO: Replace this with switch start time
+    let dateObject
+    let fronterCreated
+    if(fronter.created != null) {
+        dateObject = fronter.created;
+        fronterCreated = dateObject.toLocaleString();
     }
+    */
+    return `
+        <div class="card ${isFronting ? 'fronting' : 'non-fronting'}", style="border-left-color: #${member.color}">
+            <img src="${member.avatar_url == null ? 'blank.png' : member.avatar_url}" alt="Profile Picture">
+            <h2>${member.name}</h2>
+            <p>${member.pronouns == null ? 'This member has no pronouns set.' : member.pronouns}</p>
+        </div>
+    `
+}
 
-    // System name logic (Alli)
-    const sysObject = await getSystem(system);
-
+async function renderCards(system) {
+    // Fetch requests in parallel
+    let [fronting, members, systemInfo] = await Promise.all([
+        getFronters(system),
+        getMembers(system),
+        getSystemInfo(system)
+    ])
+    
+    // Separate the members
+    members = separateMembers(fronting, members)
+    delete fronting
+    
     // System name container
     const nameContainer = document.getElementById("name-container");
-
+    
     // System Colour
-    let colour = sysObject.color;
+    let colour = systemInfo.color;
 
-    if (sysObject.name != null) {
+    if (systemInfo.name != null) {
         // Use system's name (if it has one)
-        let sysName = sysObject.name;
+        let sysName = systemInfo.name;
         sysName += " Fronter Display";
 
         document.getElementById("tabname").innerHTML = sysName
 
         // Add system colour to title (if it has one)
         if (colour != null) {
-            nameContainer.innerHTML = `<h1><span class="title" style = "color: #${colour};"> ${sysObject.name} </span> Fronter Display</h1>`
+            nameContainer.innerHTML = `<h1><span class="title" style = "color: #${colour};"> ${systemInfo.name} </span> Fronter Display</h1>`
         } else {
             nameContainer.innerHTML = `<h1>${sysName}</h1>`
         }
@@ -90,55 +128,18 @@ async function renderFronters(system) {
             nameContainer.innerHTML = `<h1><code> ${system} </code> Fronter Display</h1>`
         }
     }
-
-    // HTMl Builder
-    let html = '';
-    fronters.members.forEach(fronter => {
-        // Avatar logic
-        let avatar
-
-        if (fronter.avatar_url != null) {
-            // Fronter's avatar
-            avatar = `<img src="${fronter.avatar_url}" alt="Profile Picture", style="float:left;">`
-        }
-        else {
-            // Use placeholder avatar if there is no avatar.
-            avatar = `<img src="blank.png" alt="Profile Picture", style="float:left;">`
-        }
-
-        // Pronouns logic (Alli)
-        let fronterPronouns
-
-        if (fronter.pronouns != null) {
-            fronterPronouns = fronter.pronouns
-        } else {
-            // Fallback for if fronter has no pronouns set
-            fronterPronouns = "This fronter has no pronouns set."
-        }
-
-        /* TODO: Replace this with switch start time
-        let dateObject
-        let fronterCreated
-        if(fronter.created != null) {
-            dateObject = fronter.created;
-            fronterCreated = dateObject.toLocaleString();
-        }
-        */
-
-        // Build fronter item
-        let htmlSegment = `<div class="fronter">
-                            ${avatar}
-                            <h2>${fronter.name}</h2>
-                            <p>${fronterPronouns}</p>
-                        </div>
-                        <br style="clear:both">`;
-
-        html += htmlSegment;
-    });
-
+    
+    let html = ''
+    for (const fronter of members.fronting) {
+        html += await renderCard(fronter, true)
+    }
+    for (const nonFronter of members.nonFronting) {
+        html += await renderCard(nonFronter, false)
+    }
+    
     // Display the formatted fronters
     container.innerHTML = html;
-
+    
     backButton()
 }
 
@@ -171,7 +172,7 @@ function showInput(reason) {
 if (system != null & system != "") {
     // Display fronters for requested system
     container.innerHTML = `<code>Loading fronters...</code>`
-    renderFronters(system);
+    renderCards(system);
 }
 else {
     // Display system input

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <head>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <hr style="width:25%; margin-left:0px; margin-right:auto;">
     
     <div class="container"></div>
-    <h1> </h1>
+    <br style="clear: both;">
     <div class="goBack"></div>
 </body>
 


### PR DESCRIPTION
Instead of only showing whoever are currently fronting, this PR makes it so that all members are shown, but fronting members are shown first and everyone else is greyed-out.

Before:
![image](https://user-images.githubusercontent.com/63091454/188572541-53ec2511-7657-4d9b-ab44-d9655413852c.png)
After:
![image](https://user-images.githubusercontent.com/63091454/188599961-a61fc107-cfe4-49c9-8e9f-eaba4687dfb5.png)

This PR also adjusts some CSS stuff slightly, like making only the right corners of avatars rounded so that there's no gap between them and the left border of the cards (they're called cards now) at the top and bottom

*Oh, and, also: I'm not plural, so may have got some language wrong... If so, sorry >.< I tried*