### PR TITLE
Separate and parallelise title rendering and card rendering

### DIFF
--- a/js/fronters.js
+++ b/js/fronters.js
@@ -93,15 +93,29 @@ async function renderCard(member, isFronting) {
 
 async function renderCards(system) {
     // Fetch requests in parallel
-    let [fronting, members, systemInfo] = await Promise.all([
+    let [fronting, members] = await Promise.all([
         getFronters(system),
-        getMembers(system),
-        getSystemInfo(system)
+        getMembers(system)
     ])
 
     // Separate the members
     members = separateMembers(fronting, members)
     delete fronting
+
+    let html = ''
+    for (const fronter of members.fronting) {
+        html += await renderCard(fronter, true)
+    }
+    for (const nonFronter of members.nonFronting) {
+        html += await renderCard(nonFronter, false)
+    }
+
+    // Display the formatted fronters
+    container.innerHTML = html
+}
+
+async function updateTitles(system) {
+    let systemInfo = await getSystemInfo(system)
 
     // System name container
     const nameContainer = document.getElementById("name-container");
@@ -132,19 +146,6 @@ async function renderCards(system) {
             nameContainer.innerHTML = `<h1><code> ${system} </code> Fronter Display</h1>`
         }
     }
-
-    let html = ''
-    for (const fronter of members.fronting) {
-        html += await renderCard(fronter, true)
-    }
-    for (const nonFronter of members.nonFronting) {
-        html += await renderCard(nonFronter, false)
-    }
-
-    // Display the formatted fronters
-    container.innerHTML = html;
-
-    backButton()
 }
 
 // Function for displaying system ID input
@@ -176,7 +177,8 @@ function showInput(reason) {
 if (system != null & system != "") {
     // Display fronters for requested system
     container.innerHTML = `<code>Loading fronters...</code>`
-    renderCards(system);
+    Promise.all([updateTitles(system), renderCards(system)])
+    backButton()
 }
 else {
     // Display system input


### PR DESCRIPTION
Previously, the `renderCards()` function would make a request for both fronter information and system information, and then update both at the same time. This is unnecessary though, because system information is only used to update the titles, and fronter information is only used to update the cards.

Now, they're separated into their own functions and run at the same time. This means that they'll update as soon as they're able to instead of waiting for the other one to finish, meaning the time to first update is slightly lower.

In practice this is an improvement of like sometimes 50ms, so it's kind of pointless... But it *is* still an improvement! It also makes the code a bit easier to understand by separating things.

As an extension to that last thing, the `backButton()` call got moved to outside of the `renderCards()` function because it didn't really make sense there.