### PR TITLE
Better error handling

### DIFF
--- a/css/fronters.css
+++ b/css/fronters.css
@@ -38,7 +38,7 @@ h1 {
     display: inline-block;
 }
 
-.container {
+.cards-container {
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
@@ -146,6 +146,7 @@ button:active, button:focus {
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding-bottom: 1.5rem;
 }
 
 .system-form > label {

--- a/index.html
+++ b/index.html
@@ -22,7 +22,8 @@
     </header>
 
     <main>
-        <div class="container"></div>
+        <div class="input-container"></div>
+        <div class="cards-container"></div>
         <br style="clear: both;">
     </main>
 

--- a/js/fronters.js
+++ b/js/fronters.js
@@ -10,7 +10,7 @@ const queryString = window.location.search;
 const system = new URLSearchParams(queryString).get("sys");
 
 // Main document container
-const container = document.querySelector('.container');
+const cardsContainer = document.querySelector('.cards-container');
 
 // Helper function for interacting with the PluralKit API
 async function pkAPI(path) {
@@ -110,7 +110,7 @@ async function renderCards(system) {
     }
 
     // Display the formatted fronters
-    container.innerHTML = html
+    cardsContainer.innerHTML = html
 }
 
 async function updateTitles(system) {
@@ -170,23 +170,37 @@ function showInput(reason) {
     }
 
     // Create form for inputting system ID
-    container.innerHTML = `<form class="system-form">
+    document.querySelector('.input-container').innerHTML = `<form class="system-form">
                             <label for="sys">${label}</label>
                             <input type="text" name="sys" id="sys">
                             <input type="submit" value="Submit">
                         </form>`
 }
 
-// Handles which display appears on the page
-if (system != null & system != "") {
-    // Display fronters for requested system
-    container.innerHTML = `<code>Loading fronters...</code>`
-    Promise.all([updateTitles(system), renderCards(system)]).catch(err => {
-        showInput(err)
-    })
-    backButton()
-}
-else {
-    // Display system input
-    showInput(null)
-};
+// Top-level await doesn't seem to work in top-level code blocks, so we put
+// everything inside an anonymous async function and call it immediately.
+(async () => {
+    // Handles which display appears on the page
+    if (system != null & system != "") {
+        // Display fronters for requested system
+        cardsContainer.innerHTML = `<code>Loading fronters...</code>`
+        try {
+            await Promise.all([
+                updateTitles(system),
+                renderCards(system).catch((err) => {
+                    // Remove the "Loading fronters..." text since they're not
+                    // being loaded anymore.
+                    cardsContainer.innerHTML = ''
+                    throw err
+            })])
+        } catch (err) {
+            console.error(`Error during rendering for system '${system}': ${err}`)
+            showInput(err)
+        }
+        backButton()
+    }
+    else {
+        // Display system input
+        showInput(null)
+    };
+})();


### PR DESCRIPTION
Instead of returning `null`s and passing them all over the place and doing lots of if checks, instead we do it the proper way with throw/catch. This means *all* errors are caught now, not just some of the ones we predicted.

`showInput()` also now has it's own dedicated container div so the cards don't get overwritten if the cards render successfully but then the titles throw an error. Errors also get logged to console.

Title error:
![image](https://user-images.githubusercontent.com/63091454/189254043-b0928318-2c8a-4a96-a2b6-6979a408b55b.png)
Card error:
![image](https://user-images.githubusercontent.com/63091454/189254096-5e1be1e2-8828-4a12-8ce4-0066d8c78e2f.png)
Both error (the first one gets displayed and the 2nd one gets ignored):
![image](https://user-images.githubusercontent.com/63091454/189261649-f7ba2666-2f32-4ecf-85ff-b10c84df69cb.png)
That error is what you get if you disconnect from the internet and try to load it, which in practice probably would never happen because this site would be on the internet... PluralKit's API being down might also be able to cause that, though. "NetworkError" is pretty not specific though so I didn't add custom text for it.