### PR TITLE
System ID format check

### DIFF
--- a/js/fronters.js
+++ b/js/fronters.js
@@ -7,7 +7,7 @@
 
 // Collect system ID from query string
 const queryString = window.location.search;
-const system = new URLSearchParams(queryString).get("sys");
+let system = new URLSearchParams(queryString).get("sys");
 
 // Main document container
 const cardsContainer = document.querySelector('.cards-container');
@@ -164,6 +164,9 @@ function showInput(reason) {
         case 429:  // Too Many Requests
             label = "Slow down! Too many requests (rate limit)."
             break
+        case 'Invalid format':  // System ID is in an invalid format
+            label = "Invalid format! System ID must be either a 5 letter ID, a Discord snowflake, or a system UUID."
+            break
         default:  // Something else happened
             label = "Unknown error: " + reason
             break
@@ -182,6 +185,24 @@ function showInput(reason) {
 (async () => {
     // Handles which display appears on the page
     if (system != null & system != "") {
+        // Lowercase the string
+        system = system.toLowerCase()
+        
+        // Check that the system requested has a valid ID
+        if (!new RegExp(
+            '^' +  // Start of line
+            '([a-z]{5}' +  // 5 letter system ID
+            '|\\d+' +  // Discord snowflake
+            '|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' +  // UUID with dashes
+            '|[0-9a-f]{32}' +  // UUID without dashes
+            '|\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}' +  // UUID surrounded by braces
+            ')$'  // End of line
+        ).test(system)) {
+            console.error(`Invalid format system ID: '${system}'`)
+            showInput('Invalid format')
+            return
+        }
+        
         // Display fronters for requested system
         cardsContainer.innerHTML = `<code>Loading fronters...</code>`
         try {

--- a/js/fronters.js
+++ b/js/fronters.js
@@ -5,10 +5,6 @@
     Purrrpley
 */
 
-// Collect system ID from query string
-const queryString = window.location.search;
-let system = new URLSearchParams(queryString).get("sys");
-
 // Main document container
 const cardsContainer = document.querySelector('.cards-container');
 
@@ -180,24 +176,31 @@ function showInput(reason) {
                         </form>`
 }
 
+function isValidFormatSystemID(systemID) {
+    return new RegExp(
+        '^' +  // Start of line
+        '([a-z]{5}' +  // 5 letter system ID
+        '|\\d+' +  // Discord snowflake
+        '|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' +  // UUID with dashes
+        '|[0-9a-f]{32}' +  // UUID without dashes
+        '|\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}' +  // UUID surrounded by braces
+        ')$'  // End of line
+    ).test(systemID)
+}
+
 // Top-level await doesn't seem to work in top-level code blocks, so we put
 // everything inside an anonymous async function and call it immediately.
 (async () => {
+    // Collect system ID from query string
+    let system = new URLSearchParams(window.location.search).get("sys")
+    
     // Handles which display appears on the page
     if (system != null & system != "") {
         // Lowercase the string
         system = system.toLowerCase()
         
-        // Check that the system requested has a valid ID
-        if (!new RegExp(
-            '^' +  // Start of line
-            '([a-z]{5}' +  // 5 letter system ID
-            '|\\d+' +  // Discord snowflake
-            '|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' +  // UUID with dashes
-            '|[0-9a-f]{32}' +  // UUID without dashes
-            '|\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}' +  // UUID surrounded by braces
-            ')$'  // End of line
-        ).test(system)) {
+        // Guard clause for invalid system IDs
+        if (!isValidFormatSystemID(system)) {
             console.error(`Invalid format system ID: '${system}'`)
             showInput('Invalid format')
             return


### PR DESCRIPTION
As you're all (I think) aware, if you input something like `vgspl#` or `vgspl?`, it breaks:
![image](https://user-images.githubusercontent.com/63091454/189324138-a3c2f6a9-7016-49f2-8cd4-a74343dcc4a3.png)
This PR adds a check before requests are made that will check that it's either a:
* 5 letter system ID
* Discord account snowflake
* UUID (including support for ones with dashes/braces)

![image](https://user-images.githubusercontent.com/63091454/189325894-618f9fc4-11ed-46da-b9af-46ee05cf1326.png)
