### PR TITLE
Add support for loading page when there's no switches logged

### DIFF
--- a/js/fronters.js
+++ b/js/fronters.js
@@ -20,7 +20,14 @@ async function pkAPI(path) {
 }
 
 async function getFronters(system) {
-    let fronters = (await pkAPI(`systems/${system}/fronters`)).members
+    try {
+        var fronters = (await pkAPI(`systems/${system}/fronters`)).members
+    } catch (err) {
+        if (err !== 204) {
+            throw err
+        }
+        return []
+    }
     // Return only the UUIDs. The other data we get from the `getMembers()`
     // call, so we only need to store it there and not here too. If the system
     // is switched out, it will return an empty array.


### PR DESCRIPTION
PluralKit's API will return `HTTP 204 (No Content)` if there's no switches logged and you request a system's fronters, instead of just returning an empty array like it does when there's no fronters but at least one switch logged.

I don't know why it does this, but it does. It's not in the documentation. Maybe a bug?

Before:
![image](https://user-images.githubusercontent.com/63091454/191889707-d473cc20-781b-41e4-9771-0837d0e4fd2a.png)
After:
![image](https://user-images.githubusercontent.com/63091454/191889861-0a92f9dc-9e56-4dc4-9766-7711f8d016a0.png)
